### PR TITLE
DR bluesky feed integration & page auto-build for fetching bluesky updates

### DIFF
--- a/.github/workflows/daily-build.yaml
+++ b/.github/workflows/daily-build.yaml
@@ -26,8 +26,9 @@ jobs:
 
       - name: Commit and push any changes
         run: |
-          git config --global user.email "juliuskobialka@gmail.com"
-          git config --global user.name "Julius Kobialka"
+          git config --global user.email "${{ github.actor }}@users.noreply.github.com"
+          git config --global user.name "${{ github.actor }}"
           git add .
-          git commit -m "Daily rebuild update" || echo "No changes to commit"
+          git commit -m "Bluesky feed rebuild update" || echo "No changes to commit"
           git push
+

--- a/.github/workflows/daily-build.yaml
+++ b/.github/workflows/daily-build.yaml
@@ -1,8 +1,9 @@
 name: Daily Build
 
 on:
-  schedule:
-    - cron: '0 0 * * *'  # This cron syntax schedules the job to run daily at midnight UTC
+  # schedule:
+  #   - cron: '0 0 * * *'  # This cron syntax schedules the job to run daily at midnight UTC
+  workflow_dispatch:  # This allows running the workflow manually from the GH Actions tab
 
 jobs:
   build:

--- a/.github/workflows/daily-build.yaml
+++ b/.github/workflows/daily-build.yaml
@@ -1,0 +1,32 @@
+name: Daily Build
+
+on:
+  schedule:
+    - cron: '0 0 * * *'  # This cron syntax schedules the job to run daily at midnight UTC
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '2.7'
+
+      - name: Install dependencies
+        run: bundle install
+
+      - name: Build the site
+        run: bundle exec jekyll build
+
+      - name: Commit and push any changes
+        run: |
+          git config --global user.email "juliuskobialka@gmail.com"
+          git config --global user.name "Julius Kobialka"
+          git add .
+          git commit -m "Daily rebuild update" || echo "No changes to commit"
+          git push

--- a/_includes/news.html
+++ b/_includes/news.html
@@ -1,6 +1,20 @@
 <section class="hero has-background-white-ter" id="news" style="padding-top: 100px; padding-bottom: 200px;">
   <div id="results-container" style="width: 90%; max-width: 1200px; margin: auto;">
-    <h1 class="title is-size-1 has-text-centered"><u>News</u></h1>
+    <h1 class="title is-size-1 has-text-centered"><u>Bluesky News</u></h1>
+    <br>
+    <br>
+    <!-- Bluesky Feed Section -->
+    <div class="columns is-multiline is-centered" id="bluesky-feed">
+      <script type="module" src="https://cdn.jsdelivr.net/npm/bsky-embed/dist/bsky-embed.es.js" async></script>
+      <bsky-embed
+        username="davidruegamer.bsky.social"
+        mode="light"
+        limit="5"
+      </bsky-embed>
+    </div>
+    <br>
+    <br>
+    <h1 class="title is-size-1 has-text-centered"><u>News Postings</u></h1>
     <br>
     <br>
     <!--Blog Cards Section-->


### PR DESCRIPTION
The modification makes use of [bsky-embed](https://github.com/Vincenius/bsky-embed) to display David's bluesky feed in a new "News" section, called "Bluesky News". One can adjust the number of posts shown. As far as I understand, jekyll is a static site generator so that the site needs to be rebuilt in order to fetch new bluesky feed updates to display. The github workflow should commit any new changes to this repository when the workflow is dispatched via the Actions tab. It's also possible to dispatch the workflow automatically, e.g., every day at midnight (see comment in `daily-build.yaml`). Unfortunately, I have no way of testing the github workflow on my local machine, so I am not sure whether it works as intended. 